### PR TITLE
마이페이지 회원탈퇴 기능 추가

### DIFF
--- a/src/apis/api/user.js
+++ b/src/apis/api/user.js
@@ -65,6 +65,20 @@ export const updateUser = async (params) => {
   }
 };
 
+/**
+ * 회원 탈퇴
+ * @param {*} params
+ * @returns
+ */
+export const deleteUser = async (params) => {
+  try {
+    const {data} = await defaultInstance.post('api/user/deleteUser', params);
+    return data;
+  } catch (e) {
+    console.log(e);
+  }
+}
+
 
 // export const getHome = () => {
 //   return request({ url: 'home' });

--- a/src/components/AccountWrapper/AccountWrapper.jsx
+++ b/src/components/AccountWrapper/AccountWrapper.jsx
@@ -2,6 +2,7 @@ import { ArrowRightCircleFill, PersonCircle } from 'react-bootstrap-icons';
 import './AccountWrapper.scss';
 import { useRecoilValue } from 'recoil';
 import { userInfoState } from '../../recoil/userInfoState';
+import DeleteUser from '../DeleteUser/DeleteUser';
 
 function AccountWrapper(props) {
     const accountInfo = useRecoilValue(userInfoState);
@@ -40,7 +41,7 @@ function AccountWrapper(props) {
                 <ArrowRightCircleFill size={18} onClick={()=>modalOpen(4)}/>
             </div>
             <div className="account__footer">
-                <button>회원탈퇴</button>
+                <button onClick={()=>modalOpen(5)}>회원탈퇴</button>
             </div>
         </div>
     );

--- a/src/components/DeleteUser/DeleteUser.jsx
+++ b/src/components/DeleteUser/DeleteUser.jsx
@@ -1,0 +1,40 @@
+import toast from "react-hot-toast";
+import { deleteUser } from "../../apis/api/user";
+import { useNavigate } from "react-router-dom";
+import { useRecoilValue, useResetRecoilState } from "recoil";
+import { userInfoState } from "../../recoil/userInfoState";
+
+function DeleteUser(props) {
+    const navigate = useNavigate();
+    const resetUserInfo = useResetRecoilState(userInfoState);
+    const BASE_URL = import.meta.env.VITE_BASE_URL;
+    const userInfo = useRecoilValue(userInfoState);
+    const onClickDelete = async () => {
+        const result = await deleteUser(userInfo.username);
+        console.log(result['data']);
+        if (result['data'] == 0) {
+            toast.error(result);
+            return false;
+        }
+        resetUserInfo();
+        navigate(BASE_URL, {replace: true});
+        toast.success("정상적으로 탈퇴되었습니다.");
+    }
+
+    return (
+        <div className='update__phone__container'>
+            <div>정말 삭제하시겠습니까?</div>
+            <hr/>
+            <div className='update__phone__form'>
+                <div className='new__phone'>
+                    제발...ㅠ
+                </div>
+                <div className='update__submit__btn'>
+                    <button type='button' onClick={() => props.setModalControl(false)}>취소</button>
+                    <button type="button" onClick={onClickDelete}>삭제</button>
+                </div>
+            </div>
+        </div>
+    );
+}
+export default DeleteUser;

--- a/src/components/DeleteUser/index.js
+++ b/src/components/DeleteUser/index.js
@@ -1,0 +1,3 @@
+import DeleteUser from "./DeleteUser";
+
+export default DeleteUser;

--- a/src/components/MyPageModalBody/MyPageModalBody.jsx
+++ b/src/components/MyPageModalBody/MyPageModalBody.jsx
@@ -3,6 +3,7 @@ import UpdateNickname from '../UpdateNickname';
 import UpdatePhone from '../UpdatePhone';
 import UpdateAdress from '../UpdateAdress';
 import './MyPageModalBody.scss';
+import DeleteUser from '../DeleteUser/DeleteUser';
 
 function MyPageModalBody(props) {
 
@@ -15,7 +16,9 @@ function MyPageModalBody(props) {
             props.modalNo === 3 ?
             <UpdatePhone setModalControl={props.setModalControl}/> :
             props.modalNo === 4 ?
-            <UpdateAdress setModalControl={props.setModalControl}/> : ''}
+            <UpdateAdress setModalControl={props.setModalControl}/> :
+            props.modalNo === 5 ?
+            <DeleteUser setModalControl={props.setModalControl}/> : ''}
         </div>
     );
 }


### PR DESCRIPTION
회원탈퇴 버튼 활성화 하였습니다.
버튼 클릭 시 모달창을 통해 탈퇴 의사 재확인이 진행됩니다.

확인 버튼 클릭 시 로그인이 풀리며 메인 화면으로 이동합니다.(toast 알림창 표시)

백엔드에도 hs-deleteUser 브랜치로 푸시하였습니다.

그 외 탈퇴 의사 확인 모달창 문구는 탈퇴했을 때의 
불이익(다양한 리뷰를 확인할 수 없어요, 유저 정보를 복구할 수 없습니다... 등)이 명확하지 않아 일단 유머러스하게 기재하였습니다.